### PR TITLE
Fix code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/Tools/去除代码注释/[实验性]remove_html_comments_noenter.py
+++ b/Tools/去除代码注释/[实验性]remove_html_comments_noenter.py
@@ -21,8 +21,8 @@ def remove_script_style_comments(content):
         return text
     
     # 对<script>和<style>标签内的内容应用replacer函数
-    content = re.sub(r'(<script[\s\S]*?>)([\s\S]*?)(</script>)', replacer, content)
-    content = re.sub(r'(<style[\s\S]*?>)([\s\S]*?)(</style>)', replacer, content)
+    content = re.sub(r'(<script[\s\S]*?>)([\s\S]*?)(</script>)', replacer, content, flags=re.IGNORECASE)
+    content = re.sub(r'(<style[\s\S]*?>)([\s\S]*?)(</style>)', replacer, content, flags=re.IGNORECASE)
     return content
 
 def remove_extra_newlines(content):

--- a/Tools/去除代码注释/remove_html_comments.py
+++ b/Tools/去除代码注释/remove_html_comments.py
@@ -19,8 +19,8 @@ def remove_script_style_comments(content):
         return text
     
     # 对<script>和<style>标签内的内容应用replacer函数
-    content = re.sub(r'(<script[\s\S]*?>)([\s\S]*?)(</script>)', replacer, content)
-    content = re.sub(r'(<style[\s\S]*?>)([\s\S]*?)(</style>)', replacer, content)
+    content = re.sub(r'(<script[\s\S]*?>)([\s\S]*?)(</script>)', replacer, content, flags=re.IGNORECASE)
+    content = re.sub(r'(<style[\s\S]*?>)([\s\S]*?)(</style>)', replacer, content, flags=re.IGNORECASE)
     return content
 
 def remove_comments_from_html(file_path):


### PR DESCRIPTION
Fixes [https://github.com/DuckDuckStudio/Fufu_Tools/security/code-scanning/2](https://github.com/DuckDuckStudio/Fufu_Tools/security/code-scanning/2)

To fix the problem, we need to modify the regular expression to be case-insensitive. This can be achieved by adding the `re.IGNORECASE` flag to the `re.sub` function calls. This will ensure that the regular expression matches `<script>`, `<SCRIPT>`, and any other case variations of the `<script>` tag. The same approach should be applied to the `<style>` tag regular expression.

The changes should be made in the `remove_script_style_comments` function, specifically on lines 22 and 23. We will add the `re.IGNORECASE` flag to the `re.sub` function calls to make the regular expressions case-insensitive.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
