### PR TITLE
fix: 修复获取脚本目录的逻辑，确保在无法确定时抛出异常，并优化读取配置文件的循环条件

### DIFF
--- a/Csharp/Show_version/Program.cs
+++ b/Csharp/Show_version/Program.cs
@@ -7,7 +7,7 @@ partial class Program
     static void Main()
     {
         // 获取当前程序的目录
-        string scriptDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        string? scriptDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? throw new InvalidOperationException("无法确定脚本所在目录。");
         string configFile = Path.Combine(scriptDir, "config.ini");
 
         // 读取配置文件
@@ -16,8 +16,8 @@ partial class Program
         try
         {
             using StreamReader sr = new(configFile, Encoding.UTF8);
-            string line;
-            while ((line = sr.ReadLine()) != null)
+            string? line;
+            while ((line = sr.ReadLine()) is not null)
             {
                 // 使用正则表达式来匹配配置项信息，并且传递 RegexOptions.Compiled 选项
                 Match match = MyRegex().Match(line);


### PR DESCRIPTION
fix [C#]: 未处理的警告 #128

### 检查清单
- [ ] 有链接Issue吗? -- Resolve #128  <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [ ] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Fufu_Tools/pulls) 吗?
- [ ] 此拉取请求仅针对一个问题/功能吗?
- [ ] 你在本地验证过你的修改吗?
- [ ] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

