### PR TITLE
docs: 从 README 中移除 WinGet 支持版本的信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 > 建议下载最新版，即使是预览版。  
 
 ### 使用 winget
-你也可以使用 _winget_ 来获取芙芙工具箱，请留意支持 _winget_ 获取的版本。  
+你也可以使用 _winget_ 来获取芙芙工具箱。  
 使用以下命令安装:  
 ```bash
 winget install --id DuckStudio.FufuTools -s winget -e
@@ -29,12 +29,6 @@ winget install --id DuckStudio.FufuTools -s winget -e
 输出类似这样:  
 ![1718315176839](https://duckduckstudio.github.io/Chinese_git/image/README/1718315176839.png)  
 > *图片上的是我的另一个项目“中文Git”的获取过程，本项目的获取过程与图片类似，但不要装错了哦！*  
-
-支持 _winget_ 安装的版本:  
-
-$$
-1.3.2 \leqslant n \leqslant 1.3.6
-$$
 
 ### 非官方渠道警告
 *(竟然会有人把我的程序放到xx下载站去啊，感觉说明比我写的都好)*  


### PR DESCRIPTION
理由：没有必要在文档中说明，用户可以直接通过以下命令获取 WinGet 支持的版本：

```pwsh
winget show --id DuckStudio.FufuTools -s winget -e --versions
```

- Resolves #197

### 检查清单
- [ ] 有链接Issue吗? -- Resolve  <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [ ] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Fufu_Tools/pulls) 吗?
- [ ] 此拉取请求仅针对一个问题/功能吗?
- [ ] 你在本地验证过你的修改吗?
- [ ] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

