### PR TITLE
pref: 在备份和还原配置文件时不显示控制台窗口

### DIFF
--- a/src/config/备份.pyw
+++ b/src/config/备份.pyw
@@ -4,7 +4,6 @@ import shutil
 import tkinter as tk
 from tkinter import filedialog
 from tkinter import messagebox
-from colorama import init, Fore
 
 def 选择目标文件夹():
     while True:
@@ -77,7 +76,6 @@ def 复制配置文件(目标文件夹):
 
 
 def main():
-    init(autoreset=True)
     # 让用户选择目标文件夹
     目标文件夹 = 选择目标文件夹()
     复制配置文件(目标文件夹)

--- a/src/config/还原.pyw
+++ b/src/config/还原.pyw
@@ -1,17 +1,19 @@
 import os
 import sys
+import shutil
 import configparser
 import tkinter as tk
 from tkinter import filedialog
 from tkinter import messagebox
-from colorama import init, Fore
-import shutil
 
 def 选择备份文件夹():
     root = tk.Tk()
     root.withdraw()
     备份文件夹 = filedialog.askdirectory(title="你之前将配置文件备份到了哪里？")
-    if not os.path.exists(备份文件夹):
+    if not 备份文件夹:
+        messagebox.showerror("错误", "未选择文件夹，操作取消。")
+        sys.exit(3)
+    elif not os.path.exists(备份文件夹):
         messagebox.showerror("错误", "备份文件夹不存在")
     return 备份文件夹
 
@@ -41,7 +43,6 @@ def 比较配置文件键(文件1, 文件2):
     return True, "键完全一致"
 
 def 还原配置文件(备份文件夹, 目标根目录):
-    init(autoreset=True)
     已处理文件 = 0
     跳过文件 = 0
 
@@ -73,10 +74,9 @@ def 还原配置文件(备份文件夹, 目标根目录):
                     messagebox.showerror("错误", f"还原配置文件 {相对路径} 失败:\n{str(e)}")
                     跳过文件 += 1
 
-    messagebox.showinfo("恭喜", f"成功还原配置文件！\n我们一共成功还原了 {已处理文件} 个配置文件，跳过了 {跳过文件} 个配置文件。")
+    messagebox.showinfo("恭喜", f"成功还原配置文件！\n一共成功还原了 {已处理文件} 个配置文件，跳过了 {跳过文件} 个配置文件。")
 
 def main():
-    init(autoreset=True)
     备份文件夹 = 选择备份文件夹()
     
     脚本路径 = os.path.abspath(sys.argv[0])

--- a/src/芙芙工具箱.pyw
+++ b/src/芙芙工具箱.pyw
@@ -234,8 +234,8 @@ categories = {
     "关于芙芙工具箱": {
         "检查版本": ".\\Show_version.py",
         "修改开始菜单图标": "link",
-        "备份配置": ".\\config\\备份.py",
-        "还原配置": ".\\config\\还原.py",
+        "备份配置": ".\\config\\备份.pyw",
+        "还原配置": ".\\config\\还原.pyw",
         "安装文件夹": os.path.dirname(os.path.abspath(__file__)),
         "程序文档": "https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/wiki/",
         "程序官网": "https://duckduckstudio.github.io/yazicbs.github.io/Tools/Fufu_Tools/",


### PR DESCRIPTION
### 检查清单
- [x] 有链接Issue吗? -- 关于 https://github.com/DuckDuckStudio/Fufu_Tools/issues/199 <!--←如有请在这里填写具体链接的议题，例如 #114-->
- [x] 你检查过没有其他重复的 [拉取请求](https://github.com/DuckDuckStudio/Fufu_Tools/pulls) 吗?
- [x] 此拉取请求仅针对一个问题/功能吗?
- [x] 你在本地验证过你的修改吗?
- [x] 你确定你的描述足以让开发人员理解你的意图以及解决方案?

### 修改说明

配置文件的另存和还原并没有用到任何输出，所以我直接将输出的依赖移除并将文件后缀从 .py 改为 .pyw 实现此优化。

<!--在这里尽可能详细的描述你做的修改，以便开发人员审查你的修改。-->

---

